### PR TITLE
NO-TICKET: Stop merge if mergeable_state is behind

### DIFF
--- a/merge/src/action.ts
+++ b/merge/src/action.ts
@@ -57,7 +57,11 @@ async function merge(
     return 'impossible';
   }
 
-  if (pull.mergeable_state === 'blocked' || pull.mergeable_state === 'draft') {
+  if (
+    pull.mergeable_state === 'blocked' ||
+    pull.mergeable_state === 'draft' ||
+    pull.mergeable_state === 'behind'
+  ) {
     console.log(`Mergeable state is ${pull.mergeable_state}. Stopping`);
     return 'skip';
   }


### PR DESCRIPTION
Skipping merge if `mergeable_state === 'behind'`.